### PR TITLE
Add ECAD Forge Gerber preview link

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ nRFBOX is a wireless toolkit designed to explore, analyze, and interact with var
 </table>
 
 
+<div>&nbsp;</div>
+
+## :mag: PCB Gerber Preview
+
+The PCB Gerber archive can be opened directly in ECAD Forge to inspect the board in the browser:
+[Open PCB/Gerber.zip in ECAD Forge](https://ecadforge.app/?url=https%3A%2F%2Fgithub.com%2Fcifertech%2FnRFBox%2Fblob%2Fmain%2FPCB%2FGerber.zip)
+
 
 
 <!-- License -->
@@ -176,4 +183,3 @@ Project Link: [https://github.com/cifertech/nRFBOX](https://github.com/cifertech
  - [ESP32-Sour-Apple](https://github.com/RapierXbox/ESP32-Sour-Apple)
 
 **Community Contributors**: Thanks to everyone who helped improve nRFBox! Your support is much appreciated!
-


### PR DESCRIPTION
Hi,

I used the great nRFBox project as a test case for my new open source online tool, ECAD Forge:
https://ecadforge.app/

The source is also available on GitHub:
https://github.com/SunboX/ecadforge_app

While testing it, I thought it might be useful to add a direct ECAD Forge link for the Gerber file. This gives other users a quick and easy way to open and inspect the file in the browser.

I am happy for feedback, bug reports, or feature requests.
